### PR TITLE
Support process-streaming-0.9.*

### DIFF
--- a/Language/Haskell/GhcImportedFrom.hs
+++ b/Language/Haskell/GhcImportedFrom.hs
@@ -167,7 +167,7 @@ shortcut (a:as) = do
 
 executeFallibly' :: String -> [String] -> IO (Maybe (String, String))
 executeFallibly' cmd args = do
-    x <- (executeFallibly (piped (proc cmd args)) (liftA2 (,) (foldOut intoLazyBytes) (foldErr intoLazyBytes)))
+    x <- (executeFallibly (piped (proc cmd args)) ((,) <$> (foldOut intoLazyBytes) <*> (foldErr intoLazyBytes)))
          `catchIOError` -- FIXME Later, propagate the error so we can log it. Top level type should be an Either or something, not a Maybe.
          (\e -> return $ Left $ show e)
 

--- a/Language/Haskell/GhcImportedFrom.hs
+++ b/Language/Haskell/GhcImportedFrom.hs
@@ -167,13 +167,13 @@ shortcut (a:as) = do
 
 executeFallibly' :: String -> [String] -> IO (Maybe (String, String))
 executeFallibly' cmd args = do
-    x <- (executeFallibly (pipeoe intoLazyBytes intoLazyBytes) (proc cmd args))
+    x <- (executeFallibly (piped (proc cmd args)) (liftA2 (,) (foldOut intoLazyBytes) (foldErr intoLazyBytes)))
          `catchIOError` -- FIXME Later, propagate the error so we can log it. Top level type should be an Either or something, not a Maybe.
          (\e -> return $ Left $ show e)
 
     return $ case x of
         Left e              -> Nothing
-        Right (_, (a, b))   -> Just $ (b2s a, b2s b)
+        Right (a, b)   -> Just $ (b2s a, b2s b)
 
   where
 

--- a/ghc-imported-from.cabal
+++ b/ghc-imported-from.cabal
@@ -36,7 +36,7 @@ library
                  , safe
                  , bytestring
                  , process
-                 , process-streaming < 0.9.0.0
+                 , process-streaming >= 0.9.0.0
                  , directory
                  , containers
                  , mtl
@@ -60,7 +60,7 @@ executable fake-ghc-for-ghc-imported-from
   hs-source-dirs:   src
   build-depends: base >=4.0 && <5
                , process
-               , process-streaming < 0.9.0.0
+               , process-streaming >= 0.9.0.0
   default-language:  Haskell2010
 
 executable ghc-imported-from
@@ -80,7 +80,7 @@ executable ghc-imported-from
                , safe
                , bytestring
                , process
-               , process-streaming < 0.9.0.0
+               , process-streaming >= 0.9.0.0
                , directory
                , containers
                , mtl
@@ -118,7 +118,7 @@ Test-Suite spec
                       , safe
                       , bytestring
                       , process
-                      , process-streaming < 0.9.0.0
+                      , process-streaming >= 0.9.0.0
                       , directory
                       , containers
                       , mtl


### PR DESCRIPTION
The 0.9 series of process streaming has been out for a couple of months; the change to make ghc-imported-from compatible with it seems straightforward.